### PR TITLE
ICDC-678 Adding colors to tables

### DIFF
--- a/src/main/frontend/src/components/Disclaimer/DisclaimerView.js
+++ b/src/main/frontend/src/components/Disclaimer/DisclaimerView.js
@@ -6,8 +6,6 @@ import {
 } from "@material-ui/core";
 import { Typography } from "../Wrappers/Wrappers";
 import WarningIcon from '@material-ui/icons/Warning';
-import cn from '../../utils/classNameConcat';
-
 
 
  function PositionedSnackbar({ classes }) {

--- a/src/main/frontend/src/components/Stats/StatsView.js
+++ b/src/main/frontend/src/components/Stats/StatsView.js
@@ -81,7 +81,8 @@ const styles = (theme) => ({
     },
     paper: {
         textAlign: 'center',
-        background: theme.custom.cardBackGround
+        background: theme.custom.cardBackGround,
+        boxShadow: 'none'
     },
 });
 

--- a/src/main/frontend/src/themes/dark.js
+++ b/src/main/frontend/src/themes/dark.js
@@ -113,6 +113,19 @@ export default {
         backgroundColor: "white"
       }
     },
+    MUIDataTableHeadCell: {
+      fixedHeader:{
+        backgroundColor: primary,
+        color: 'white'
+      }
+    },
+    MUIDataTableBodyRow: {
+      root: {
+        '&:nth-child(even)': { 
+          backgroundColor: '#f5f5f5'
+        }
+      }
+    },
     MuiTableRow: {
       root: {
         height: 56,

--- a/src/main/frontend/src/themes/light.js
+++ b/src/main/frontend/src/themes/light.js
@@ -112,9 +112,22 @@ export default {
         backgroundColor: "white"
       }
     },
+    MUIDataTableHeadCell: {
+      fixedHeader:{
+        backgroundColor: primary,
+        color: 'white'
+      }
+    },
     MuiTableRow: {
       root: {
         height: 56,
+      }
+    },
+    MUIDataTableBodyRow: {
+      root: {
+        '&:nth-child(even)': { 
+          backgroundColor: '#f5f5f5'
+        }
       }
     },
     MuiTableCell: {


### PR DESCRIPTION
**Changes**

1. Overridden default colors for the tables in our themes.
2. Removed Box shadow around the stats component.
3. Removed unused variables.


<img width="2560" alt="Screen Shot 2019-08-07 at 5 32 21 PM" src="https://user-images.githubusercontent.com/26462504/62659470-72189980-b939-11e9-93b7-9054eef4c7cb.png">
