### PR TITLE
About page style fixes

### DIFF
--- a/src/main/frontend/src/pages/about/aboutView.js
+++ b/src/main/frontend/src/pages/about/aboutView.js
@@ -12,6 +12,7 @@ const About = ({ classes }) => {
   }
   return (
     <React.Fragment>
+      <div className={classes.tabContainer}>
       <Tabs
         indicatorColor='primary'
         textColor='primary'
@@ -26,42 +27,15 @@ const About = ({ classes }) => {
       </Tabs>
       {value === 0 && <SteeringCommittee />}
       {value === 1 && <DGAB />}
+      </div>
     </React.Fragment>
   );
 };
 
 const styles = theme => ({
-  container: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    top: 0,
-    left: 0
-  },
-  divider: {
-    height: "1px",
-    width: "800px"
-  },
-  paperRoot: {
-    boxShadow: "none",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    paddingTop: theme.spacing.unit * 12,
-    paddingBottom: theme.spacing.unit * 16,
-    paddingLeft: theme.spacing.unit * 6,
-    paddingRight: theme.spacing.unit * 6,
-    maxWidth: 800
-  },
-  errorTextRow: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    width: 500
-  },
-  dogHumanHelix: {
-    width: 400
+  tabContainer: {
+    margin: "16px auto",
+    maxWidth: "900px"
   }
 });
 

--- a/src/main/frontend/src/pages/steeringCommittee/steeringCommitteeView.js
+++ b/src/main/frontend/src/pages/steeringCommittee/steeringCommitteeView.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { withStyles } from "@material-ui/core";
 import SteeringCommitteeTable from "./steeringCommitteeTable";
+import { Typography } from "../../components/Wrappers/Wrappers";
 
 const SteeringCommittee = ({ classes, theme, data }) => {
   return (
@@ -8,47 +9,58 @@ const SteeringCommittee = ({ classes, theme, data }) => {
       <div className={classes.titleContainer}>
         <div className={classes.pageTitle}>Steering Committee</div>
       </div>
-      <p className={classes.paragraphStyle}>
-        Among the important NCI principles related to data commons is
-        "community-driven", meaning that the data commons will be built with
-        input and collaboration from many groups to foster a diversity of ideas
-        and to ensure needs are identified across the broad research community.
-        To achieve this, the NCI/FNLCR formed a Steering Committee (SC) to
-        advise on the Integrated Canine Data Commons (ICDC). The initial work by
-        the Steering Committee is to discuss the data for the ICDC and identify
-        use cases for working with the data in the ICDC. The Steering Committee
-        plays an important role in sourcing data for incorporation in the ICDC
-        and in early use and feedback of the ICDC focusing on the gathered use
-        cases.{" "}
-      </p>
-      <p className={classes.paragraphStyle}>
-        The SC has two subcommittees: the Data Governance Advisory Board (DGAB)
-        and the Best Practices Sub-Committee (BPSC).
-      </p>
-      <p className={classes.paragraphStyle}>
-        The DGAB is charged with managing the data submission requests (link to
-        data submission page) to the ICDC during the prototype phase of the
-        project. It has developed a process by which the community can request
-        their project be added to the ICDC. All requests are tracked, reviewed,
-        and prioritized by the DGAB. The prioritized list is provided to a
-        Senior Advisory Committee at NCI, which determines which data will be
-        included in ICDC. Decisions are tracked and communicated to all relevant
-        stakeholders, in a timely manner.
-      </p>
-      <p className={classes.paragraphStyle}>
-        The Best Practices Subcommittee (BPSC) has responsibility for
-        identifying and recommending best practices that the ICDC will implement
-        to streamline and harmonize data collection, standardize data formats
-        and platforms, and manage and annotate data (especially clinical data).
-        The ICDC prototype will encompass imagin, clinical/pathologic,
-        multi-omic, and immunologic data. The overall goal of the BPSC will be
-        to streamline and standardize data collection and management for canine
-        studies. The BPSC will examine past and planned studies and will
-        recommend prospective standards for data collection and management.{" "}
-      </p>
-      <p className={classes.paragraphStyle}>
-        <SteeringCommitteeTable />
-      </p>
+      <Typography>
+        <p className={classes.paragraphStyle}>
+          Among the important NCI principles related to data commons is
+          "community-driven", meaning that the data commons will be built with
+          input and collaboration from many groups to foster a diversity of
+          ideas and to ensure needs are identified across the broad research
+          community. To achieve this, the NCI/FNLCR formed a Steering Committee
+          (SC) to advise on the Integrated Canine Data Commons (ICDC). The
+          initial work by the Steering Committee is to discuss the data for the
+          ICDC and identify use cases for working with the data in the ICDC. The
+          Steering Committee plays an important role in sourcing data for
+          incorporation in the ICDC and in early use and feedback of the ICDC
+          focusing on the gathered use cases.{" "}
+        </p>{" "}
+      </Typography>
+      <Typography>
+        <p className={classes.paragraphStyle}>
+          The SC has two subcommittees: the Data Governance Advisory Board
+          (DGAB) and the Best Practices Sub-Committee (BPSC).
+        </p>{" "}
+      </Typography>
+      <Typography>
+        <p className={classes.paragraphStyle}>
+          The DGAB is charged with managing the data submission requests (link
+          to data submission page) to the ICDC during the prototype phase of the
+          project. It has developed a process by which the community can request
+          their project be added to the ICDC. All requests are tracked,
+          reviewed, and prioritized by the DGAB. The prioritized list is
+          provided to a Senior Advisory Committee at NCI, which determines which
+          data will be included in ICDC. Decisions are tracked and communicated
+          to all relevant stakeholders, in a timely manner.
+        </p>{" "}
+      </Typography>
+      <Typography>
+        <p className={classes.paragraphStyle}>
+          The Best Practices Subcommittee (BPSC) has responsibility for
+          identifying and recommending best practices that the ICDC will
+          implement to streamline and harmonize data collection, standardize
+          data formats and platforms, and manage and annotate data (especially
+          clinical data). The ICDC prototype will encompass imagin,
+          clinical/pathologic, multi-omic, and immunologic data. The overall
+          goal of the BPSC will be to streamline and standardize data collection
+          and management for canine studies. The BPSC will examine past and
+          planned studies and will recommend prospective standards for data
+          collection and management.{" "}
+        </p>{" "}
+      </Typography>
+      <Typography>
+        <p className={classes.paragraphStyle}>
+          <SteeringCommitteeTable />
+        </p>{" "}
+      </Typography>
     </div>
   );
 };


### PR DESCRIPTION
**Changes:**

1. Changes the font family of steering committee page.
2. Centered the tabs view on about page


<img width="1516" alt="Screen Shot 2019-09-16 at 10 09 17 AM" src="https://user-images.githubusercontent.com/26462504/64965007-30e5a480-d86a-11e9-8e76-637a2ce00c81.png">
